### PR TITLE
HPCC-24425 Skip agent improvement

### DIFF
--- a/esp/logging/logginglib/loggingagentbase.hpp
+++ b/esp/logging/logginglib/loggingagentbase.hpp
@@ -146,6 +146,7 @@ interface IEspUpdateLogRequestWrap : extends IInterface
     virtual IPropertyTree* getUserContext()=0;
     virtual IPropertyTree* getUserRequest()=0;
     virtual IPropertyTree* getLogRequestTree()=0;
+    virtual IPropertyTree* getScriptValuesTree()=0;
     virtual IInterface* getExtraLog()=0;
     virtual const char* getBackEndRequest()=0;
     virtual const char* getBackEndResponse()=0;
@@ -159,6 +160,7 @@ interface IEspUpdateLogRequestWrap : extends IInterface
     virtual void setUserContext(IPropertyTree* val)=0;
     virtual void setUserRequest(IPropertyTree* val)=0;
     virtual void setLogRequestTree(IPropertyTree* val)=0;
+    virtual void setScriptValuesTree(IPropertyTree* val)=0;
     virtual void setExtraLog(IInterface* val)=0;
     virtual void setBackEndRequest(const char* val)=0;
     virtual void setBackEndResponse(const char* val)=0;
@@ -178,6 +180,7 @@ class CUpdateLogRequestWrap : implements IEspUpdateLogRequestWrap, public CInter
     Owned<IPropertyTree> userContext;
     Owned<IPropertyTree> userRequest;
     Owned<IPropertyTree> logRequestTree;
+    Owned<IPropertyTree> scriptValuesTree;
     Owned<IInterface> extraLog;
     StringAttr  backEndRequest, backEndResponse;
     StringAttr  userResponse;
@@ -218,6 +221,7 @@ public:
         backEndResponse.clear();
         updateLogRequest.clear();
         logRequestTree.clear();
+        scriptValuesTree.clear();
         extraLog.clear();
     };
 
@@ -228,6 +232,7 @@ public:
     IPropertyTree* getUserContext() {return userContext.getLink();};
     IPropertyTree* getUserRequest() {return userRequest.getLink();};
     IPropertyTree* getLogRequestTree() {return logRequestTree.getLink();};
+    IPropertyTree* getScriptValuesTree() override {return scriptValuesTree.getLink();};
     IInterface* getExtraLog() {return extraLog.getLink();};
     const char* getBackEndRequest() {return backEndRequest.get();};
     const char* getBackEndResponse() {return backEndResponse.get();};
@@ -241,6 +246,7 @@ public:
     void setUserContext(IPropertyTree* val) {userContext.setown(val);};
     void setUserRequest(IPropertyTree* val) {userRequest.setown(val);};
     void setLogRequestTree(IPropertyTree* val) {logRequestTree.setown(val);};
+    void setScriptValuesTree(IPropertyTree* val) override {scriptValuesTree.setown(val);};
     void setExtraLog(IInterface* val) {extraLog.setown(val);};
     void setBackEndRequest(const char* val) {backEndRequest.set(val);};
     void setBackEndResponse(const char* val) {backEndResponse.set(val);};

--- a/esp/logging/logginglib/logthread.cpp
+++ b/esp/logging/logginglib/logthread.cpp
@@ -70,6 +70,11 @@ CLogThread::CLogThread(IPropertyTree* _cfg , const char* _service, const char* _
 
     logAgent.setown(_logAgent);
 
+    //leave the fact that a script can leverage this name as an option undocumented, naming scheme could change,
+    //  controlling the queue is a very low level mechanism and should be frowned upon
+    //  once scripts can communicate with the agent that should be the mechanism to skip a particular type of logging
+    controlName.appendf("thread-queue-%s-%s", _service, _agentName);
+
     maxLogQueueLength = _cfg->getPropInt(PropMaxLogQueueLength, MaxLogQueueLength);
     signalGrowingQueueAt = _cfg->getPropInt(PropQueueSizeSignal, QueueSizeSignal);
     maxLogRetries = _cfg->getPropInt(PropMaxTriesRS, DefaultMaxTriesRS);

--- a/esp/logging/logginglib/logthread.hpp
+++ b/esp/logging/logginglib/logthread.hpp
@@ -112,6 +112,7 @@ interface IUpdateLogThread : extends IInterface
     virtual bool queueLog(IEspUpdateLogRequestWrap* logRequest) = 0;
     virtual void sendLog() = 0;
     virtual ILogRequestReader* getLogRequestReader() = 0;
+    virtual const char *queryControlName() = 0;
 };
 
 class CLogThread : public Thread , implements IUpdateLogThread
@@ -121,6 +122,8 @@ class CLogThread : public Thread , implements IUpdateLogThread
     int maxLogQueueLength;
     int signalGrowingQueueAt;
     unsigned maxLogRetries;   // Max. # of attempts to send log message
+
+    StringBuffer controlName;
 
     Owned<IEspLogAgent> logAgent;
     QueueOf<IInterface, false> logQueue;
@@ -140,7 +143,7 @@ class CLogThread : public Thread , implements IUpdateLogThread
     IEspUpdateLogRequestWrap* readJobQueue();
     IEspUpdateLogRequestWrap* checkAndReadLogRequestFromSharedTankFile(IEspUpdateLogRequestWrap* logRequest);
     void checkAndCreateFile(const char* fileName);
-
+    const char *queryControlName() override {return controlName;}
 public:
     IMPLEMENT_IINTERFACE;
 

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -238,6 +238,7 @@ bool CLoggingManager::updateLog(IEspContext* espContext, IEspUpdateLogRequestWra
         if (espContext)
             espContext->addTraceSummaryTimeStamp(LogMin, "LMgr:startQLog");
 
+        Owned<IPropertyTree> scriptValues = req.getScriptValuesTree();
         if (oneTankFile)
         {
             Owned<CLogRequestInFile> reqInFile = new CLogRequestInFile();
@@ -261,13 +262,17 @@ bool CLoggingManager::updateLog(IEspContext* espContext, IEspUpdateLogRequestWra
                 IUpdateLogThread* loggingThread = loggingAgentThreads[x];
                 if (loggingThread->hasService(LGSTUpdateLOG))
                 {
+                    //leave the fact that a script can control the thread queue as an option undocumented, naming scheme could change,
+                    //  controlling the queue is a very low level mechanism and should be frowned upon
+                    //  once scripts can communicate with the agent that should be the mechanism to skip a particular type of logging
+                    if (checkSkipThreadQueue(scriptValues, loggingThread->queryControlName()))
+                        continue;
                     loggingThread->queueLog(logRequest);
                 }
             }
         }
         else
         {
-            Owned<IPropertyTree> scriptValues = req.getScriptValuesTree();
             for (unsigned int x = 0; x < loggingAgentThreads.size(); x++)
             {
                 IUpdateLogThread* loggingThread = loggingAgentThreads[x];

--- a/esp/logging/loggingmanager/loggingmanager.cpp
+++ b/esp/logging/loggingmanager/loggingmanager.cpp
@@ -219,59 +219,60 @@ bool CLoggingManager::updateLog(IEspContext* espContext, IEspUpdateLogRequestWra
     return bRet;
 }
 
-static bool checkEnabledLogEntry(IPropertyTree *scriptValues, const char *profile, const char *group, unsigned &groupEntryCount, const char *logtype, unsigned &typeEntryCount)
+static bool checkEnabledLogEntry(IPropertyTree *scriptValues, const char *profile, const char* agent, const char *group, const char *logtype)
 {
-    if ((!group || *group) && (!logtype || !*logtype)) //get this special case out of the way
-        return false;
-    //we only care about groups if a profile is specified, if so does it match?
-    if (profile && *profile && group && *group)
+    bool enabled = true;
+    bool haveProfile = !isEmptyString(profile);
+    bool haveGroup = !isEmptyString(group);
+    bool haveType = !isEmptyString(logtype);
+    if (haveProfile && (!haveGroup || !strieq(profile, group)))
     {
-        groupEntryCount++;
-        if (!strieq(profile, group))
-            return false; //don't need to fall through and check types this group doesn't match
+        ESPLOG(LogNormal, "'%s' log entry disabled - profile '%s' =/= group '%s'", agent, profile, group);
+        enabled = false;
     }
-    //if an entry has an enabled group but no type that entry is enabled
-    if (!logtype || !*logtype)
-        return true;
-    typeEntryCount++;
-    //if our type isn't disabled then this entry is enabled
-    VStringBuffer xpath("@disable-log-type-%s", logtype);
-    return (!scriptValues->getPropBool(xpath, false));
+    else if (haveType)
+    {
+        VStringBuffer xpath("@disable-log-type-%s", logtype);
+        if (scriptValues->getPropBool(xpath, false))
+        {
+            ESPLOG(LogNormal, "'%s' log entry disabled - log type '%s' disabled", agent, logtype);
+            enabled = false;
+        }
+    }
+    if (enabled)
+    {
+        if (haveProfile && haveType)
+            ESPLOG(LogMax, "'%s' log entry enabled - profile '%s' == group '%s' and type '%s' not disabled", agent, profile, group, logtype);
+        else if (haveProfile)
+            ESPLOG(LogMax, "'%s' log entry enabled - profile '%s' == group '%s' and type not specified", agent, profile, group);
+        else if (haveType)
+            ESPLOG(LogMax, "'%s' log entry enabled - group '%s' unrestricted and type '%s' not disabled", agent, group, logtype);
+        else
+            ESPLOG(LogMax, "'%s' log entry enabled - group '%s' unrestricted and type not specified", agent, group);
+    }
+    return enabled;
 }
 
 bool checkSkipThreadQueue(IPropertyTree *scriptValues, IUpdateLogThread &logthread)
 {
     if (!scriptValues)
         return false;
-    const char *controlName = logthread.queryControlName();
-    if (controlName && *controlName)
-    {
-        VStringBuffer controlAttr("@%s", controlName);
-        const char *controlValue = scriptValues->queryProp(controlAttr);
-        if (controlValue && strieq(controlValue, "skip"))
-            return true;
-    }
     Linked<IEspLogAgent> agent = logthread.getLogAgent(); //badly named function get does not link
     if (!agent)
         return false;
     const char *profile = scriptValues->queryProp("@profile");
 
-    unsigned groupEntryCount = 0;
-    unsigned groupEntriesDisabled = 0;
-    unsigned typeEntryCount = 0;
-    unsigned typeEntriesDisabled = 0;
-
     Owned<IEspLogAgentVariantIterator> variants = agent->getVariants();
     ForEach(*variants)
     {
-        //a single enabled entry means we can't skip.  Unfortunately group="", type="" may be an artifact? treat it as non-existent
-        if (checkEnabledLogEntry(scriptValues, profile, variants->query().getGroup(), groupEntryCount, variants->query().getType(), typeEntryCount))
-            return false;
+        const IEspLogAgentVariant& variant = variants->query();
+        if (checkEnabledLogEntry(scriptValues, profile, variant.getName(), variant.getGroup(), variant.getType()))
+        {
+            IERRLOG("log agent '%s' skipped for internal testing; reverse Boolean on next line", variant.getName());
+            return true;
+        }
     }
-    //if nothing was defined/checked then we're defacto enabled
-    if (groupEntryCount==0 && typeEntryCount==0)
-        return false;
-    //things were checked but each was disabled
+    ESPLOG(LogNormal, "skipping log agent '%s' - all entries disabled", agent->getName());
     return true;
 }
 
@@ -285,7 +286,7 @@ bool CLoggingManager::updateLog(IEspContext* espContext, IEspUpdateLogRequestWra
         if (espContext)
             espContext->addTraceSummaryTimeStamp(LogMin, "LMgr:startQLog");
 
-        Owned<IPropertyTree> scriptValues = req.getScriptValuesTree();
+        Linked<IPropertyTree> scriptValues = req.getScriptValuesTree();
         if (oneTankFile)
         {
             Owned<CLogRequestInFile> reqInFile = new CLogRequestInFile();

--- a/esp/logging/loggingmanager/loggingmanager.h
+++ b/esp/logging/loggingmanager/loggingmanager.h
@@ -31,6 +31,7 @@ interface IEspLogEntry  : implements IInterface
     virtual void setOwnUserContextTree(IPropertyTree* tree) = 0;
     virtual void setOwnUserRequestTree(IPropertyTree* tree) = 0;
     virtual void setOwnLogInfoTree(IPropertyTree* tree) = 0;
+    virtual void setOwnScriptValuesTree(IPropertyTree* extra) = 0;
     virtual void setOwnExtraLog(IInterface* extra) = 0;
     virtual void setOption(const char* ptr) = 0;
     virtual void setLogContent(const char* ptr) = 0;
@@ -43,6 +44,7 @@ interface IEspLogEntry  : implements IInterface
     virtual IPropertyTree* getUserContextTree() = 0;
     virtual IPropertyTree* getUserRequestTree() = 0;
     virtual IPropertyTree* getLogInfoTree() = 0;
+    virtual IPropertyTree* getScriptValuesTree() = 0;
     virtual IInterface* getExtraLog() = 0;
     virtual const char* getOption() = 0;
     virtual const char* getLogContent() = 0;

--- a/esp/logging/loggingmanager/loggingmanager.hpp
+++ b/esp/logging/loggingmanager/loggingmanager.hpp
@@ -39,6 +39,7 @@ class CEspLogEntry : implements IEspLogEntry, public CInterface
     Owned<IPropertyTree> userContextTree;
     Owned<IPropertyTree> userRequestTree;
     Owned<IPropertyTree> logInfoTree;
+    Owned<IPropertyTree> scriptValuesTree;
     Owned<IInterface> extraLog;
 
 public:
@@ -50,6 +51,7 @@ public:
     void setOwnUserContextTree(IPropertyTree* tree) { userContextTree.setown(tree); };
     void setOwnUserRequestTree(IPropertyTree* tree) { userRequestTree.setown(tree); };
     void setOwnLogInfoTree(IPropertyTree* tree) { logInfoTree.setown(tree); };
+    void setOwnScriptValuesTree(IPropertyTree* tree) override { scriptValuesTree.setown(tree); };
     void setOwnExtraLog(IInterface* extra) { extraLog.setown(extra); };
     void setOption(const char* ptr) { option.set(ptr); };
     void setLogContent(const char* ptr) { logContent.set(ptr); };
@@ -62,6 +64,7 @@ public:
     IPropertyTree* getUserContextTree() { return userContextTree; };
     IPropertyTree* getUserRequestTree() { return userRequestTree; };
     IPropertyTree* getLogInfoTree() { return logInfoTree; };
+    IPropertyTree* getScriptValuesTree() override { return scriptValuesTree; };
     IInterface* getExtraLog() { return extraLog; };
     const char* getOption() { return option.get(); };
     const char* getLogContent() { return logContent.get(); };
@@ -86,7 +89,7 @@ class CLoggingManager : implements ILoggingManager, public CInterface
     unsigned serializeLogRequestContent(IEspUpdateLogRequestWrap* request, const char* GUID, StringBuffer& logData);
 
     bool updateLog(IEspContext* espContext, IEspUpdateLogRequestWrap& req, IEspUpdateLogResponse& resp, StringBuffer& status);
-    bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* userContext, IPropertyTree* userRequest,
+    bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* userContext, IPropertyTree* userRequest, IPropertyTree *scriptValues,
         const char* backEndReq, const char* backEndResp, const char* userResp, const char* logDatasets, StringBuffer& status);
     bool updateLog(IEspContext* espContext, const char* option, const char* logContent, StringBuffer& status);
     bool updateLog(IEspContext* espContext, const char* option, IPropertyTree* logInfo, IInterface* extraLog, StringBuffer& status);

--- a/esp/services/esdl_svc_engine/esdl_binding.cpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.cpp
@@ -650,6 +650,26 @@ static inline bool isPublishedQuery(EsdlMethodImplType implType)
     return (implType==EsdlMethodImplRoxie || implType==EsdlMethodImplWsEcl);
 }
 
+IEsdlScriptContext* EsdlServiceImpl::checkCreateEsdlServiceScriptContext(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg)
+{
+    IEsdlCustomTransform *methodCrt = m_customRequestTransformMap.getValue(mthdef.queryMethodName());
+    if (!m_serviceLevelRequestTransform && !methodCrt)
+        return nullptr;
+
+    Owned<IEsdlScriptContext> scriptContext = createEsdlScriptContext(&context);
+
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "service", srvdef.queryName());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "method", mthdef.queryMethodName());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request_type", mthdef.queryRequestType());
+    scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request", mthdef.queryRequestType());  //this could diverge from request_type in the future
+
+    if (tgtcfg)
+        scriptContext->setContent(ESDLScriptCtxSection_TargetConfig, tgtcfg);
+    if (m_oEspBindingCfg)
+        scriptContext->setContent(ESDLScriptCtxSection_BindingConfig, m_oEspBindingCfg.get());
+    return scriptContext.getClear();
+}
+
 void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
                                            IEsdlDefService &srvdef,
                                            IEsdlDefMethod &mthdef,
@@ -662,14 +682,14 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
                                            StringBuffer &logdata,
                                            unsigned int flags)
 {
+    Owned<IEsdlScriptContext> scriptContext;
+
     const char *mthName = mthdef.queryName();
     context.addTraceSummaryValue(LogMin, "method", mthName);
     const char* srvName = srvdef.queryName();
 
     if (m_serviceLevelCrtFail)
         throw MakeStringException(-1, "%s::%s disabled due to Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
-
-    IEsdlCustomTransform *crt = m_customRequestTransformMap.getValue(mthdef.queryMethodName());
 
     Owned<MethodAccessMap>* authMap = m_methodAccessMaps.getValue(mthdef.queryMethodName());
     if (authMap != nullptr && authMap->get() != nullptr)
@@ -856,6 +876,9 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
         }
         else
         {
+            //Future: support transforms for all transaction types by moving scripts and script processing up
+            scriptContext.setown(checkCreateEsdlServiceScriptContext(context, srvdef, mthdef, tgtcfg));
+
             Owned<IXmlWriterExt> reqWriter = createIXmlWriterExt(0, 0, NULL, WTStandard);
 
             //Preprocess Request
@@ -871,7 +894,7 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
             reqcontent.set(reqWriter->str());
             context.addTraceSummaryTimeStamp(LogNormal, "serialized-xmlreq");
 
-            handleFinalRequest(context, m_serviceLevelRequestTransform, crt, tgtcfg, tgtctx, srvdef, mthdef, ns, reqcontent, origResp, isPublishedQuery(implType), implType==EsdlMethodImplProxy, soapmsg);
+            handleFinalRequest(context, scriptContext, tgtcfg, tgtctx, srvdef, mthdef, ns, reqcontent, origResp, isPublishedQuery(implType), implType==EsdlMethodImplProxy, soapmsg);
             context.addTraceSummaryTimeStamp(LogNormal, "end-HFReq");
 
             if (isPublishedQuery(implType))
@@ -891,13 +914,16 @@ void EsdlServiceImpl::handleServiceRequest(IEspContext &context,
     }
 
     context.addTraceSummaryTimeStamp(LogNormal, "srt-resLogging");
-    handleResultLogging(context, tgtctx.get(), req, soapmsg.str(), origResp.str(), out.str(), logdata.str());
+    handleResultLogging(context, scriptContext, tgtctx.get(), req, soapmsg.str(), origResp.str(), out.str(), logdata.str());
     context.addTraceSummaryTimeStamp(LogNormal, "end-resLogging");
     ESPLOG(LogMax,"Customer Response: %s", out.str());
 }
 
-bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,const char *rawreq, const char * rawresp, const char * finalresp, const char * logdata)
+bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IEsdlScriptContext *scriptContext, IPropertyTree * reqcontext, IPropertyTree * request,const char *rawreq, const char * rawresp, const char * finalresp, const char * logdata)
 {
+    Owned<IPropertyTree> scriptValues = scriptContext->createPTreeFromSection(ESDLScriptCtxSection_Logging);
+    StringBuffer sv;
+    puts(toXML(scriptValues, sv));
     bool success = true;
     if (m_oLoggingManager)
     {
@@ -910,7 +936,8 @@ bool EsdlServiceImpl::handleResultLogging(IEspContext &espcontext, IPropertyTree
         entry->setBackEndReq(rawreq);
         entry->setBackEndResp(rawresp);
         entry->setLogDatasets(logdata);
-
+        if (scriptContext)
+            entry->setOwnScriptValuesTree(scriptContext->createPTreeFromSection(ESDLScriptCtxSection_Logging));
         StringBuffer logresp;
         success = m_oLoggingManager->updateLog(entry, logresp);
         ESPLOG(LogMin,"ESDLService: Attempted to log ESP transaction: %s", logresp.str());
@@ -1036,8 +1063,7 @@ void EsdlServiceImpl::getSoapError( StringBuffer& out,
 }
 
 void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
-                                         IEsdlCustomTransform *serviceCrt,
-                                         IEsdlCustomTransform *methodCrt,
+                                         IEsdlScriptContext *scriptContext,
                                          Owned<IPropertyTree> &tgtcfg,
                                          Owned<IPropertyTree> &tgtctx,
                                          IEsdlDefService &srvdef,
@@ -1052,7 +1078,7 @@ void EsdlServiceImpl::handleFinalRequest(IEspContext &context,
     const char *tgtUrl = tgtcfg->queryProp("@url");
     if (!isEmptyString(tgtUrl))
     {
-        prepareFinalRequest(context, serviceCrt, methodCrt, tgtcfg, tgtctx, srvdef, mthdef, isroxie, ns, req, soapmsg);
+        prepareFinalRequest(context, scriptContext, tgtcfg, tgtctx, srvdef, mthdef, isroxie, ns, req, soapmsg);
         sendTargetSOAP(context, tgtcfg.get(), soapmsg.str(), out, isproxy, NULL);
     }
     else
@@ -1340,8 +1366,7 @@ void EsdlServiceImpl::getTargetResponseFile(IEspContext & context,
  */
 
 void EsdlServiceImpl::prepareFinalRequest(IEspContext &context,
-                                        IEsdlCustomTransform *serviceCrt,
-                                        IEsdlCustomTransform *methodCrt,
+                                        IEsdlScriptContext *scriptContext,
                                         Owned<IPropertyTree> &tgtcfg,
                                         Owned<IPropertyTree> &tgtctx,
                                         IEsdlDefService &srvdef,
@@ -1427,39 +1452,22 @@ void EsdlServiceImpl::prepareFinalRequest(IEspContext &context,
     // access to them, so pull them from ourself. When they are passed in the
     // error checking has already been completed.
 
-    if (!serviceCrt)
+    if (m_serviceLevelCrtFail)
+        throw MakeStringException(-1, "%s::%s disabled due to service-level Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
+
+    m_serviceLevelRequestTransform;
+
+    StringAttr *crtErrorMessage = m_methodCRTransformErrors.getValue(mthName);
+    if (crtErrorMessage && !crtErrorMessage->isEmpty())
+        throw MakeStringException(-1, "%s::%s disabled due to method-level Custom Transform errors: %s. Review transform template in configuration.", srvdef.queryName(), mthName, crtErrorMessage->str());
+
+    if (scriptContext)
     {
-        if (m_serviceLevelCrtFail)
-            throw MakeStringException(-1, "%s::%s disabled due to service-level Custom Transform errors. Review transform template in configuration.", srvdef.queryName(), mthName);
+        IEsdlCustomTransform *methodCrt = m_customRequestTransformMap.getValue(mthName);
 
-        serviceCrt = m_serviceLevelRequestTransform;
-    }
-
-    if (!methodCrt)
-    {
-        StringAttr *crtErrorMessage = m_methodCRTransformErrors.getValue(mthName);
-        if (crtErrorMessage && !crtErrorMessage->isEmpty())
-            throw MakeStringException(-1, "%s::%s disabled due to method-level Custom Transform errors: %s. Review transform template in configuration.", srvdef.queryName(), mthName, crtErrorMessage->str());
-
-        methodCrt = m_customRequestTransformMap.getValue(mthName);
-    }
-
-    if (serviceCrt || methodCrt)
-    {
         context.addTraceSummaryTimeStamp(LogNormal, "srt-custreqtrans");
-
-        //as we add more entry points the script context will move to wider scope
-        Owned<IEsdlScriptContext> scriptContext = createEsdlScriptContext(&context);
         scriptContext->setContent(ESDLScriptCtxSection_ESDLRequest, reqProcessed.str());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "service", srvdef.queryName());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "method", mthdef.queryMethodName());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request_type", mthdef.queryRequestType());
-        scriptContext->setAttribute(ESDLScriptCtxSection_ESDLInfo, "request", mthdef.queryRequestType());  //this could diverge from request_type in the future
-
-        scriptContext->setContent(ESDLScriptCtxSection_TargetConfig, tgtcfg);
-        scriptContext->setContent(ESDLScriptCtxSection_BindingConfig, m_oEspBindingCfg.get());
-
-        processServiceAndMethodTransforms(scriptContext, {serviceCrt, methodCrt}, ESDLScriptCtxSection_ESDLRequest, ESDLScriptCtxSection_FinalRequest);
+        processServiceAndMethodTransforms(scriptContext, {m_serviceLevelRequestTransform, methodCrt}, ESDLScriptCtxSection_ESDLRequest, ESDLScriptCtxSection_FinalRequest);
         scriptContext->toXML(reqProcessed.clear(), ESDLScriptCtxSection_FinalRequest);
 
         context.addTraceSummaryTimeStamp(LogNormal, "end-custreqtrans");
@@ -3356,8 +3364,9 @@ int EsdlBindingImpl::onGetRoxieBuilder(CHttpRequest* request, CHttpResponse* res
                     getRequestContent(*context, reqcontent, request, srvname, mthname, ns, ROXIEREQ_FLAGS);
 
                     tgtctx.setown( m_pESDLService->createTargetContext(*context, tgtcfg, *defsrv, *defmth, req_pt));
-                    
-                    m_pESDLService->prepareFinalRequest(*context, nullptr, nullptr, tgtcfg, tgtctx, *defsrv, *defmth, true, ns.str(), reqcontent, roxiemsg);
+
+                    Owned<IEsdlScriptContext> scriptContext = m_pESDLService->checkCreateEsdlServiceScriptContext(*context, *defsrv, *defmth, tgtcfg.get());
+                    m_pESDLService->prepareFinalRequest(*context, scriptContext, tgtcfg, tgtctx, *defsrv, *defmth, true, ns.str(), reqcontent, roxiemsg);
                 }
                 else
                 {

--- a/esp/services/esdl_svc_engine/esdl_binding.hpp
+++ b/esp/services/esdl_svc_engine/esdl_binding.hpp
@@ -168,6 +168,8 @@ public:
     void addServiceLevelRequestTransform(IPropertyTree *customRequestTransform);
     void addMethodLevelRequestTransform(const char *method, IPropertyTree &methodCfg, IPropertyTree *customRequestTransform);
 
+    IEsdlScriptContext* checkCreateEsdlServiceScriptContext(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, IPropertyTree *tgtcfg);
+
     virtual void handleServiceRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, const char *ns, const char *schema_location, IPropertyTree *req, StringBuffer &out, StringBuffer &logdata, unsigned int flags);
     virtual void generateTransactionId(IEspContext & context, StringBuffer & trxid)=0;
     void generateTargetURL(IEspContext & context, IPropertyTree *srvinfo, StringBuffer & url, bool isproxy);
@@ -179,12 +181,12 @@ public:
     virtual void processHeaders(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req, StringBuffer &headers){};
     virtual void processRequest(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &req) {};
     virtual void processResponse(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer &resp) {};
-    void prepareFinalRequest(IEspContext &context, IEsdlCustomTransform *serviceCrt, IEsdlCustomTransform *methodCrt, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, bool isroxie, const char* ns, StringBuffer &reqcontent, StringBuffer &reqProcessed);
+    void prepareFinalRequest(IEspContext &context, IEsdlScriptContext *scriptContext, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, bool isroxie, const char* ns, StringBuffer &reqcontent, StringBuffer &reqProcessed);
     virtual void createServersList(IEspContext &context, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, StringBuffer &servers) {};
-    virtual bool handleResultLogging(IEspContext &espcontext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawreq, const char * rawresp, const char * finalresp, const char * logdata);
+    virtual bool handleResultLogging(IEspContext &espcontext, IEsdlScriptContext *scriptContext, IPropertyTree * reqcontext, IPropertyTree * request,  const char * rawreq, const char * rawresp, const char * finalresp, const char * logdata);
     void handleEchoTest(const char *mthName, IPropertyTree *req, StringBuffer &soapResp, ESPSerializationFormat format);
     void handlePingRequest(const char *srvName, StringBuffer &out, unsigned int flags);
-    virtual void handleFinalRequest(IEspContext &context, IEsdlCustomTransform *srvCrt, IEsdlCustomTransform *mthCrt, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer& req, StringBuffer &out, bool isroxie, bool isproxy, StringBuffer &rawreq);
+    virtual void handleFinalRequest(IEspContext &context, IEsdlScriptContext *scriptContext, Owned<IPropertyTree> &tgtcfg, Owned<IPropertyTree> &tgtctx, IEsdlDefService &srvdef, IEsdlDefMethod &mthdef, const char *ns, StringBuffer& req, StringBuffer &out, bool isroxie, bool isproxy, StringBuffer &rawreq);
     void getSoapBody(StringBuffer& out,StringBuffer& soapresp);
     void getSoapError(StringBuffer& out,StringBuffer& soapresp,const char *,const char *);
 

--- a/system/xmllib/libxml_xpathprocessor.cpp
+++ b/system/xmllib/libxml_xpathprocessor.cpp
@@ -908,8 +908,9 @@ void copyXmlNode(IPropertyTree *tree, xmlNodePtr node)
 {
     for(xmlAttrPtr att=node->properties;att!=nullptr; att=att->next)
     {
+        VStringBuffer name("@%s", (const char *)att->name);
         xmlChar *value = xmlGetProp(node, att->name);
-        tree->setProp((const char *)att->name, (const char *)value);
+        tree->setProp(name, (const char *)value);
         xmlFree(value);
     }
 
@@ -1171,6 +1172,16 @@ private:
         xmlOutputBufferClose(xmlOut);
 
     }
+    virtual IPropertyTree *createPTreeFromSection(const char *section) override
+    {
+        if (isEmptyString(section))
+            return nullptr;
+        xmlNodePtr sect = getSectionNode(section, nullptr);
+        if (!sect)
+            return nullptr;
+        return createPtreeFromXmlNode(sect);
+    }
+
     virtual void toXML(StringBuffer &xml) override
     {
         toXML(xml, nullptr, true);

--- a/system/xmllib/xpathprocessor.hpp
+++ b/system/xmllib/xpathprocessor.hpp
@@ -115,6 +115,7 @@ interface IEsdlScriptContext : extends IInterface
     virtual bool getXPathBool(const char *xpath, bool dft=false) const = 0;
     virtual void toXML(StringBuffer &xml, const char *section, bool includeParentNode=false) = 0;
     virtual void toXML(StringBuffer &xml) = 0;
+    virtual IPropertyTree *createPTreeFromSection(const char *section) = 0;
 };
 
 extern "C" XMLLIB_API IEsdlScriptContext *createEsdlScriptContext(void * espContext);


### PR DESCRIPTION
Restructured skip queue logic to simplify and to log the decision making
process. Eliminated the special case of empty type and group:
- If a profile is set, an empty group skips the log entry.
- If no type is set the log entry not skipped due to group is enabled.
- If no control statements were processed, the settings section won't
  exist and the log entries won't be processed.
- If control statements were processed, it seems like empty type and group
  will be a rare enough occurrence that the benefit of simplified code
  outweighs whatever slight additional processing cost may be incurred.

Fixed reference count bug leading to double deletion.

Signed-off-by: Tim Klemm <tim.klemm@lexisnexisrisk.com>